### PR TITLE
Fix list-repos job by using compact JSON output

### DIFF
--- a/.github/workflows/claude-org-wide.yml
+++ b/.github/workflows/claude-org-wide.yml
@@ -49,7 +49,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PHPSTAN_BOT_TOKEN }}
         run: |
           repos=$(gh api --paginate "/orgs/${{ github.repository_owner }}/repos?type=public&per_page=100" \
-            --jq '[.[].full_name]' | jq -s 'add')
+            --jq '[.[].full_name]' | jq -s -c 'add')
           echo "repos=$repos" >> "$GITHUB_OUTPUT"
 
   run-on-repo:


### PR DESCRIPTION
The jq command was producing pretty-printed multi-line JSON, which
broke GITHUB_OUTPUT parsing. Adding -c flag to jq ensures the repos
array is written as a single line, preventing the "Invalid format"
error.

https://claude.ai/code/session_013mQhze9GtX3gtArxPdyGFD