### PR TITLE
fix: use custom_instructions instead of prompt in org-wide workflow

### DIFF
--- a/.github/workflows/claude-org-wide.yml
+++ b/.github/workflows/claude-org-wide.yml
@@ -76,11 +76,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
           trigger_phrase: "@phpstan-bot"
-          prompt: |
-            You are working on the repository ${{ matrix.repo }}.
+          claude_args: >-
+            --model claude-opus-4-6
+            --custom-instructions "You are working on the repository ${{ matrix.repo }}.
             After making changes, you must create a pull request (not a draft) with your changes.
-            Do not just push a branch — always open a real, non-draft pull request so the changes can be reviewed and merged.
-          claude_args: "--model claude-opus-4-6"
+            Do not just push a branch — always open a real, non-draft pull request so the changes can be reviewed and merged."
           bot_name: "phpstan-bot"
           bot_id: "79867460"
           additional_permissions: |


### PR DESCRIPTION
The `prompt` input overrides the trigger comment content, which means the user's actual instructions from the comment are lost. Moving the instructions to `--custom-instructions` via `claude_args` preserves the comment as the primary task while keeping the supplementary instructions (create PRs, not drafts, etc.) as guidance.

Closes #5