### PR TITLE
fix: detect default branch dynamically before checkout

### DIFF
--- a/.github/workflows/claude-org-wide.yml
+++ b/.github/workflows/claude-org-wide.yml
@@ -64,10 +64,19 @@ jobs:
       matrix:
         repo: ${{ fromJson(needs.list-repos.outputs.repos) }}
     steps:
+      - name: "Get default branch of target repository"
+        id: default-branch
+        env:
+          GH_TOKEN: ${{ secrets.PHPSTAN_BOT_TOKEN }}
+        run: |
+          default_branch=$(gh api "repos/${{ matrix.repo }}" --jq '.default_branch')
+          echo "branch=$default_branch" >> "$GITHUB_OUTPUT"
+
       - name: "Checkout target repository"
         uses: actions/checkout@v4
         with:
           repository: ${{ matrix.repo }}
+          ref: ${{ steps.default-branch.outputs.branch }}
           token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
 
       - name: "Run Claude Code on repository"


### PR DESCRIPTION
The `actions/checkout` step was not specifying a `ref`, causing it to default to the workflow repository's default branch (`main`) instead of the target repository's default branch. This adds a step that queries the GitHub API for each target repo's default branch and passes it as the `ref` parameter.

Closes #7

Generated with [Claude Code](https://claude.ai/code)